### PR TITLE
Support false as value

### DIFF
--- a/lib/provider.ex
+++ b/lib/provider.ex
@@ -99,9 +99,7 @@ defmodule Toml.Provider do
 
   # For all other values, convert tables to keywords
   defp to_keyword2(map) when is_map(map) do
-    map
-    |> Enum.into([])
-    |> Enum.map(fn {k, v} -> {k, to_keyword2(v)} end)
+    Enum.map(map, fn {k, v} -> {k, to_keyword2(v)} end)
   end
 
   # And leave all other values untouched

--- a/lib/provider.ex
+++ b/lib/provider.ex
@@ -99,9 +99,9 @@ defmodule Toml.Provider do
 
   # For all other values, convert tables to keywords
   defp to_keyword2(map) when is_map(map) do
-    for {k, v} <- map, v2 = to_keyword2(v), into: [] do
-      {k, v2}
-    end
+    map
+    |> Enum.into([])
+    |> Enum.map(fn {k, v} -> {k, to_keyword2(v)} end)
   end
 
   # And leave all other values untouched

--- a/test/fixtures/provider.toml
+++ b/test/fixtures/provider.toml
@@ -1,5 +1,7 @@
 [toml]
 provider_test = "success!"
+provider_active = true
+provider_disabled = false
 
 [toml.nested]
 foo = "bar"

--- a/test/provider_test.exs
+++ b/test/provider_test.exs
@@ -11,7 +11,7 @@ defmodule Toml.Test.ProviderTest do
     assert {:ok, true} = Toml.Provider.get([:toml, :provider_active])
 
     assert false == Application.get_env(:toml, :provider_disabled)
-    assert {:ok, false} = Toml.Provider.get([:toml, :provider_active])
+    assert {:ok, false} = Toml.Provider.get([:toml, :provider_disabled])
 
     Application.put_env(:toml, :provider_test, nil)
     assert nil == Application.get_env(:toml, :provider_test)

--- a/test/provider_test.exs
+++ b/test/provider_test.exs
@@ -9,7 +9,7 @@ defmodule Toml.Test.ProviderTest do
 
     assert true == Application.get_env(:toml, :provider_active)
     assert {:ok, true} = Toml.Provider.get([:toml, :provider_active])
-    
+
     assert false == Application.get_env(:toml, :provider_disabled)
     assert {:ok, false} = Toml.Provider.get([:toml, :provider_active])
 

--- a/test/provider_test.exs
+++ b/test/provider_test.exs
@@ -7,6 +7,12 @@ defmodule Toml.Test.ProviderTest do
     assert "success!" = Application.get_env(:toml, :provider_test)
     assert {:ok, "success!"} = Toml.Provider.get([:toml, :provider_test])
 
+    assert true == Application.get_env(:toml, :provider_active)
+    assert {:ok, true} = Toml.Provider.get([:toml, :provider_active])
+    
+    assert false == Application.get_env(:toml, :provider_disabled)
+    assert {:ok, false} = Toml.Provider.get([:toml, :provider_active])
+
     Application.put_env(:toml, :provider_test, nil)
     assert nil == Application.get_env(:toml, :provider_test)
 


### PR DESCRIPTION
As reported on #6, right now the provider does not load false values. This PR aims to solve this issue.

The cause of the problem was because list comprehensions discard all elements for which the filter expression returns false or nil. So whenever a value was false, this value was been discarded. A solution that I find for this was use the function [`Enum.into/2`](https://hexdocs.pm/elixir/Enum.html#into/2) to convert the map to a Keyword instead of the list comprehension.