### PR TITLE
move path expansion to load, fix doc typo, fix test

### DIFF
--- a/lib/provider.ex
+++ b/lib/provider.ex
@@ -66,8 +66,7 @@ defmodule Toml.Provider do
 
     if is_distillery_env?() do
       # When running under Distillery, init performs load
-      _ = load([], opts)
-      :ok
+      load([], opts)
     else
       # With 1.9 releases, init just preps arguments for `load`
       opts

--- a/lib/provider.ex
+++ b/lib/provider.ex
@@ -66,7 +66,7 @@ defmodule Toml.Provider do
 
     if is_distillery_env?() do
       # When running under Distillery, init performs load
-      load([], opts)
+      _ = load([], opts)
       :ok
     else
       # With 1.9 releases, init just preps arguments for `load`
@@ -207,11 +207,11 @@ defmodule Toml.Provider do
     expand_var(rest, <<acc::binary, c::utf8>>)
   end
 
-  defp is_distillery_env? do
-    if @has_config_api do
+  if @has_config_api do
+    defp is_distillery_env? do
       Code.ensure_loaded?(Distillery.Releases.Config.Provider)
-    else
-      true
     end
+  else
+    defp is_distillery_env?, do: true
   end
 end

--- a/lib/provider.ex
+++ b/lib/provider.ex
@@ -67,6 +67,7 @@ defmodule Toml.Provider do
     if is_distillery_env?() do
       # When running under Distillery, init performs load
       load([], opts)
+      opts
     else
       # With 1.9 releases, init just preps arguments for `load`
       opts
@@ -206,11 +207,11 @@ defmodule Toml.Provider do
     expand_var(rest, <<acc::binary, c::utf8>>)
   end
 
-  if @has_config_api do
-    defp is_distillery_env? do
+  defp is_distillery_env? do
+    if @has_config_api do
       Code.ensure_loaded?(Distillery.Releases.Config.Provider)
+    else
+      false
     end
-  else
-    defp is_distillery_env?, do: true
   end
 end

--- a/lib/provider.ex
+++ b/lib/provider.ex
@@ -1,7 +1,7 @@
 defmodule Toml.Provider do
   @moduledoc """
-  This module provides an implementation of both the Distilery and Elixir 
-  config provider behaviours, so that TOML files can be used for configuration 
+  This module provides an implementation of both the Distilery and Elixir
+  config provider behaviours, so that TOML files can be used for configuration
   in releases.
 
   ## Distillery Usage
@@ -19,7 +19,7 @@ defmodule Toml.Provider do
 
       config_providers: [
         {Toml.Provider, [
-          path: {:system, "XDG_CONFIG_DIR", "myapp.toml",
+          path: {:system, "XDG_CONFIG_DIR", "myapp.toml"},
           transforms: [...]
         ]}
       ]
@@ -42,7 +42,7 @@ defmodule Toml.Provider do
   but there are two main differences:
 
     * `:path` (required) - sets the path to the TOML file to load config from
-    * `:keys` - defaults to `:atoms`, but can be set to `:atoms!` if desired, all other 
+    * `:keys` - defaults to `:atoms`, but can be set to `:atoms!` if desired, all other
       key types are ignored, as it results in an invalid config structure
 
   """
@@ -55,8 +55,6 @@ defmodule Toml.Provider do
 
   @doc false
   def init(opts) when is_list(opts) do
-    path = Keyword.fetch!(opts, :path)
-
     opts =
       case Keyword.get(opts, :keys) do
         a when a in [:atoms, :atoms!] ->
@@ -66,28 +64,29 @@ defmodule Toml.Provider do
           Keyword.put(opts, :keys, :atoms)
       end
 
-    with {:ok, expanded} <- expand_path(path) do
-      opts = Keyword.put(opts, :path, expanded)
-
-      if is_distillery_env?() do
-        # When running under Distillery, init performs load
-        load([], opts)
-        :ok
-      else
-        # With 1.9 releases, init just preps arguments for `load`
-        opts
-      end
+    if is_distillery_env?() do
+      # When running under Distillery, init performs load
+      load([], opts)
+      :ok
     else
-      {:error, reason} ->
-        exit(reason)
+      # With 1.9 releases, init just preps arguments for `load`
+      opts
     end
   end
 
   @doc false
   def load(config, opts) when is_list(opts) do
     path = Keyword.fetch!(opts, :path)
-    map = Toml.decode_file!(path, opts)
-    persist(config, to_keyword(map))
+    # path expansion should happen in load rather than init, otherwise
+    # in 1.9 releases using a {:system, env_var, path} tuple an error
+    # will be raised if the env var is not set in the build environment
+    with {:ok, path} <- expand_path(path) do
+      map = Toml.decode_file!(path, opts)
+      persist(config, to_keyword(map))
+    else
+      {:error, reason} ->
+        exit(reason)
+    end
   end
 
   @doc false

--- a/test/provider_test.exs
+++ b/test/provider_test.exs
@@ -30,12 +30,14 @@ defmodule Toml.Test.ProviderTest do
 
     opts = Toml.Provider.init(path: file)
     config = Toml.Provider.load(config, opts)
+    Application.put_all_env(config)
+
     assert "success!" = Application.get_env(:toml, :provider_test)
     assert {:ok, "success!"} = Toml.Provider.get([:toml, :provider_test])
   end
 
   test "exit is triggered if path provided has invalid expansion" do
-    assert catch_exit(Toml.Provider.init(path: "path/to/${HOME")) == :unclosed_var_expansion
+    assert catch_exit(Toml.Provider.load([], path: "path/to/${HOME")) == :unclosed_var_expansion
   end
 
   test "can expand paths" do


### PR DESCRIPTION
Hey Paul, 

I was playing with using Elixir 1.9 releases with toml master and ran into a snag where I'd get an error during release assembly if the env var for my toml config path wasn't set in my build environment. Looks like the path expansion needs to happen in load rather than init to avoid that. I went ahead and tweaked that as well as added a missing bracket in the doc example and made a failing test pass while I was in there.

I successfully deployed with this branch via both elixir 1.9 releases and via distillery so there doesn't seem to be any downside to moving the path expansion to the load step.

Thanks!
Adam