### PR TITLE
Persist configs after merging

### DIFF
--- a/lib/provider.ex
+++ b/lib/provider.ex
@@ -103,7 +103,9 @@ defmodule Toml.Provider do
 
   if has_config_api? do
     defp persist(config, keyword) when is_list(keyword) do
-      Config.Reader.merge(config, keyword)
+      config = Config.Reader.merge(config, keyword)
+      Application.put_all_env(config, persistent: true)
+      config
     end
   else
     defp persist(config, keyword) when is_list(keyword) do


### PR DESCRIPTION
Prior to this commit when using the Toml.Provider as a Distillery config
provider with Elixir 1.9+, configuration changes made in the
corresponding .toml files were not reflected in the running application.
This commit adds a call to `Application.put_all_env` after deep-merging
the configurations to ensure that the merge is available to all
processes afterwards.

Co-authored-by: Jed Schneider <jed.schneider@gmail.com>
Co-authored-by: Brent Yoder <brent.yoder@testdouble.com>
Co-authored-by: Greg Baraghimian <greggreg@gmail.com>

Fixes #23 