### PR TITLE
Revert persist config api

### DIFF
--- a/test/provider_test.exs
+++ b/test/provider_test.exs
@@ -1,3 +1,6 @@
+defmodule Distillery.Releases.Config.Provider do
+end
+
 defmodule Toml.Test.ProviderTest do
   use ExUnit.Case
 
@@ -34,6 +37,16 @@ defmodule Toml.Test.ProviderTest do
 
     assert "success!" = Application.get_env(:toml, :provider_test)
     assert {:ok, "success!"} = Toml.Provider.get([:toml, :provider_test])
+  end
+
+  test "deep merges to ensure existing config is preserved" do
+    file = Path.join([__DIR__, "fixtures", "provider.toml"])
+    Application.put_all_env(toml: [nested: [deep: "success!"]])
+
+    opts = Toml.Provider.init(path: file, keys: :atoms!)
+
+    assert Toml.Provider.is_distillery_env?()
+    assert [deep: "success!", foo: "bar"] = Application.get_env(:toml, :nested)
   end
 
   test "exit is triggered if path provided has invalid expansion" do

--- a/test/provider_test.exs
+++ b/test/provider_test.exs
@@ -43,9 +43,8 @@ defmodule Toml.Test.ProviderTest do
     file = Path.join([__DIR__, "fixtures", "provider.toml"])
     Application.put_all_env(toml: [nested: [deep: "success!"]])
 
-    opts = Toml.Provider.init(path: file, keys: :atoms!)
+    Toml.Provider.init(path: file, keys: :atoms!)
 
-    assert Toml.Provider.is_distillery_env?()
     assert [deep: "success!", foo: "bar"] = Application.get_env(:toml, :nested)
   end
 


### PR DESCRIPTION
Fixes #26 

This reverts the changes introduced to the `persist` function of `Provider` that leverage the `Config` API.

Those changes introduce a bug where existing app configuration isn't merged correctly.