### PR TITLE
Fix buggy test assertion code

### DIFF
--- a/test/support/assertions.ex
+++ b/test/support/assertions.ex
@@ -51,6 +51,7 @@ defmodule Toml.Test.Assertions do
           do_deep_equal(av, bv)
         end
       end
+      |> Enum.all?()
     else
       false
     end
@@ -66,6 +67,7 @@ defmodule Toml.Test.Assertions do
       for {ai, bi} <- Enum.zip(asort, bsort) do
         do_deep_equal(ai, bi)
       end
+      |> Enum.all?()
     else
       a == b
     end


### PR DESCRIPTION
When comparing maps of equal size, the value returned from the [`do_deep_equal/2`](https://github.com/bitwalker/toml-elixir/blob/a8b9872d11a6169eb8995b6a5e06fb2dfdd0c39e/test/support/assertions.ex#L42) helper is the value of the [`for` loop](https://github.com/bitwalker/toml-elixir/blob/a8b9872d11a6169eb8995b6a5e06fb2dfdd0c39e/test/support/assertions.ex#L47-L53)—a list. That's a problem, given that `do_deep_equals/2` is expected to return a boolean: the one place where `do_deep_equals/2` is used is as [the condition for an `if`](https://github.com/bitwalker/toml-elixir/blob/a8b9872d11a6169eb8995b6a5e06fb2dfdd0c39e/test/support/assertions.ex#L35).

When comparing maps of equal size, `do_deep_equals/2` will thus always return a truthy value, as all lists are truthy in elixir. This means that the test suite treats any map with the correct number of keys as deeply equal to the result, which causes tests that rightly should fail to pass.

A similar issue [arises for lists](https://github.com/bitwalker/toml-elixir/blob/a8b9872d11a6169eb8995b6a5e06fb2dfdd0c39e/test/support/assertions.ex#L66-L68), where two lists of the same length are always treated as deeply equal, for the same reason.

I have fixed both of these, by piping the `for` loop evaluates into `Enum.all?/1`—only if each iteration of the for loop returned `true` should `do_deep_equals/2` return `true`.

Unfortunately, this PR causes the test suite to fail. That should be expected: the test suite is in fact broken, and tests _should_ be failing with a fixed `do_deep_equals/2`.